### PR TITLE
gravatar export explicit on server and client

### DIFF
--- a/package.js
+++ b/package.js
@@ -5,6 +5,6 @@ Package.describe({
 Package.on_use(function (api) {
   api.use('crypto-md5', ['client', 'server']);
   if(api.export)
-    api.export('Gravatar');
+    api.export(['Gravatar'], ['client', 'server']);
   api.add_files('gravatar.js', ['client', 'server']);
 });


### PR DESCRIPTION
I don't know the exact signature for api.export, but this one worked for me on client + server, whereas the other one was failing on the server for me.
